### PR TITLE
add Input layer name to YoloV3 and YoloV3Tiny

### DIFF
--- a/yolov3_tf2/models.py
+++ b/yolov3_tf2/models.py
@@ -203,7 +203,7 @@ def yolo_nms(outputs, anchors, masks, classes):
 
 def YoloV3(size=None, channels=3, anchors=yolo_anchors,
            masks=yolo_anchor_masks, classes=80, training=False):
-    x = inputs = Input([size, size, channels])
+    x = inputs = Input([size, size, channels], name='input')
 
     x_36, x_61, x = Darknet(name='yolo_darknet')(x)
 
@@ -234,7 +234,7 @@ def YoloV3(size=None, channels=3, anchors=yolo_anchors,
 
 def YoloV3Tiny(size=None, channels=3, anchors=yolo_tiny_anchors,
                masks=yolo_tiny_anchor_masks, classes=80, training=False):
-    x = inputs = Input([size, size, channels])
+    x = inputs = Input([size, size, channels], name='input')
 
     x_8, x = DarknetTiny(name='yolo_darknet')(x)
 


### PR DESCRIPTION
If no input name is given to the models, an error is experienced when transferring the input weights